### PR TITLE
M: take the window aspect ratio into consideration when renderint texts

### DIFF
--- a/src/render/text_uimodel.h
+++ b/src/render/text_uimodel.h
@@ -4,7 +4,7 @@
 class TextUiModel : public UiModel
 {
     virtual void CollectVertices( Widget const& Wdg, UiVertexInserter_t& Inserter )const;
-    static bool CalcRequiredSize( Widget const& Wdg, glm::vec2& OutReqSize, std::string& OutBuf );
+    static bool CalcRequiredSize( Widget const& Wdg, glm::vec2& OutReqSize, std::string& OutBuf, float Ratio );
 };
 
 #endif//INCLUDED_RENDER_TEXT_UIMODEL_H


### PR DESCRIPTION
After the changes, the aspect ratio in the font bitmap file will be used. A possible improvement / customization option would be an optional argument to text ui elements, a ratio to distort the fonts.
