### PR TITLE
A: CMake scripts to download & build external dependencies along with the main project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@ project(Reaping2)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake_support)
 
+if(NOT DEFINED REAPING2_DEPS_INSTALL_DIR AND EXISTS ${PROJECT_SOURCE_DIR}/local)
+    set(REAPING2_DEPS_INSTALL_DIR ${PROJECT_SOURCE_DIR}/local)
+endif()
+
 include( FindDeps ) 
 include( CMakeHelper )
 
@@ -28,6 +32,9 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE ${CMAKE_CURRENT_SOURCE_DIR}/bin/relea
 if(WIN32)
     set( WIN32_ENET_INCLUDE_WS2_32 ws2_32.lib )
     set( WIN32_ENET_INCLUDE_WINMM winmm.lib )
+    # Had to use this when compiled debug+64bit with msvc
+    # see: https://msdn.microsoft.com/en-us/library/8578y171.aspx
+    set( CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /bigobj" )
 endif(WIN32)
 
 link_directories(

--- a/cmake_support/ArchDetect.cmake
+++ b/cmake_support/ArchDetect.cmake
@@ -1,0 +1,27 @@
+SET(ARCH_C_SOURCE "
+#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64) || defined(_M_X64)
+    #error ArchDetect x86_64
+#elif defined(__ia64) || defined(__ia64__) || defined(_M_IA64)
+    #error ArchDetect ia64
+#elif defined(__i386) || defined(__i386__) || defined(_M_IX86)
+    #error ArchDetect i386
+#endif
+
+#error cmake_ARCH unkown
+")
+
+FUNCTION(DETECT_ARCHITECTURE OutVar)
+    ENABLE_LANGUAGE(C)
+    FILE(WRITE "${CMAKE_BINARY_DIR}/arch.c" "${ARCH_C_SOURCE}")
+    TRY_RUN(
+        run_result_unused
+        compile_result_unused
+        "${CMAKE_BINARY_DIR}"
+        "${CMAKE_BINARY_DIR}/arch.c"
+        COMPILE_OUTPUT_VARIABLE ARCH)
+        string(REGEX MATCH "ArchDetect ([a-zA-Z0-9_]+)" ARCH "${ARCH}")
+        string(REPLACE "ArchDetect " "" ARCH "${ARCH}")
+
+    SET(${OutVar} "${ARCH}" PARENT_SCOPE)
+endfunction()
+

--- a/cmake_support/FindDeps.cmake
+++ b/cmake_support/FindDeps.cmake
@@ -3,7 +3,11 @@ if(WIN32)
 	# ugly boost bug workaround, boost w/ static build crashes in codecvt
 	set( Boost_USE_STATIC_LIBS ON )
 endif(WIN32)
-find_package( Boost 1.59 COMPONENTS filesystem system thread date_time program_options atomic serialization )
+if(NOT DEFINED BOOST_ROOT)
+    set(BOOST_ROOT ${REAPING2_DEPS_INSTALL_DIR})
+    set(Boost_ADDITIONAL_VERSIONS 1.59 1.60)
+endif()
+find_package( Boost 1.59 COMPONENTS filesystem system thread date_time program_options atomic serialization chrono )
 
 if( NOT Boost_FOUND )
 	message( FATAL_ERROR "Cannot find Boost!" )
@@ -13,61 +17,62 @@ find_package( OpenGL )
 
 # add possible lib names at the end of the arg list
 macro( my_find_package pkg_name header default_lib_name )
-	if(WIN32)
-		set( lib_names ${ARGN})
-		find_path( ${pkg_name}_INCLUDE_DIR ${header} PATHS $ENV{${pkg_name}_INCLUDEDIR} )
-		find_library( ${pkg_name}_LIBRARY NAMES ${default_lib_name} ${lib_names} PATHS $ENV{${pkg_name}_LIBRARYDIR} )
-		set( ${pkg_name}_INCLUDE_DIRS ${${pkg_name}_INCLUDE_DIR} CACHE PATH "" FORCE )
-		set( ${pkg_name}_LIBRARIES ${${pkg_name}_LIBRARY} CACHE PATH "" FORCE )
-		message( "${pkg_name}: ${${pkg_name}_INCLUDE_DIR} ${${pkg_name}_LIBRARIES}" )
-	else(WIN32)
-		find_package( ${pkg_name} )
-		if(NOT ${${pkg_name}_FOUND} )
-			message( "${pkg_name} not found! Default: ${default_lib_name} " )
-			set( ${pkg_name}_LIBRARY ${default_lib_name} CACHE PATH "" FORCE )
-			set( ${pkg_name}_INCLUDE_DIR "" CACHE PATH "" FORCE )
-			set( ${pkg_name}_INCLUDE_DIRS ${${pkg_name}_INCLUDE_DIR} CACHE PATH "" FORCE )
-			set( ${pkg_name}_LIBRARIES ${${pkg_name}_LIBRARY} CACHE PATH "" FORCE )
-		else()
-#			message( "${pkg_name} found!" )
-#			if(NOT ${pkg_name}_INCLUDE_DIRS )
-#				set( ${pkg_name}_INCLUDE_DIRS ${${pkg_name}_INCLUDE_DIR} CACHE PATH "" FORCE )
-#			endif()
-#			if(NOT ${pkg_name}_LIBRARIES )
-#				set( ${pkg_name}_LIBRARIES ${${pkg_name}_LIBRARY} CACHE PATH "" FORCE )
-#			endif()
-		endif()
-		message( "${pkg_name}: ${${pkg_name}_INCLUDE_DIR} ${${pkg_name}_LIBRARY}" )
-		
-	endif(WIN32)
+
+    find_package( ${pkg_name} QUIET )
+
+    if(NOT ${${pkg_name}_FOUND})
+        message(STATUS "Package ${pkg_name} not found! Trying to find paths manually ...")
+
+	    if( NOT "${header}" STREQUAL "" )
+            find_path(${pkg_name}_INCLUDE_DIR ${header}
+                PATHS
+                    ${REAPING2_DEPS_INSTALL_DIR}/include
+                    $ENV{${pkg_name}_INCLUDEDIR})
+            if(NOT ${pkg_name}_INCLUDE_DIR)
+                message(FATAL_ERROR "${pkg_name} include dir not found! Searched for: ${header}" )
+	        endif(NOT ${pkg_name}_INCLUDE_DIR)
+	    endif( NOT "${header}" STREQUAL "" )
+
+	    if( NOT "${default_lib_name}" STREQUAL "" )
+            set(lib_names ${ARGN})
+            find_library(${pkg_name}_LIBRARY
+                NAMES ${default_lib_name} ${lib_names}
+                PATHS
+                    ${REAPING2_DEPS_INSTALL_DIR}/lib
+                    $ENV{${pkg_name}_LIBRARYDIR})
+            if(NOT ${pkg_name}_LIBRARY)
+                message(FATAL_ERROR "${pkg_name} library not found! Searched for: ${default_lib_name};${lib_names}")
+            endif()
+	    endif( NOT "${default_lib_name}" STREQUAL "" )
+
+        set( ${pkg_name}_INCLUDE_DIRS ${${pkg_name}_INCLUDE_DIR} CACHE PATH "" FORCE )
+        set( ${pkg_name}_LIBRARIES ${${pkg_name}_LIBRARY} CACHE PATH "" FORCE )
+
+        message( STATUS "${pkg_name} include dir: \"${${pkg_name}_INCLUDE_DIR}\" library: \"${${pkg_name}_LIBRARY}\"" )
+    else()
+        message( STATUS "${pkg_name} found!" )
+    endif()
+
+
 endmacro( my_find_package )
 
-my_find_package( GLEW GL/glew.h GLEW glew32s glew glew32 )
+my_find_package( GLEW GL/glew.h GLEW glew32s glew32sd )
 
 my_find_package( GLFW GLFW/glfw3.h glfw glfw3 glfw3dll )
 
 if(WIN32)
-	find_path( GLM_INCLUDE_DIR glm/glm.hpp PATHS $ENV{GLM_INCLUDEDIR} )
-	message( "GLM: ${GLM_INCLUDE_DIR}" )
-	string( COMPARE EQUAL ${GLM_INCLUDE_DIR} "GLM_INCLUDE_DIR-NOTFOUND" glm_missing )
-	if( ${glm_missing} )
-		message( FATAL_ERROR "GLM not found ")
-	endif()
+    my_find_package( GLM glm/glm.hpp "" )
 else()
-	set( GLM_INCLUDE_DIR "" )
+    set( glm_include_dir "" )
 endif()
 
 my_find_package( LIBOGG ogg/ogg.h ogg libogg libogg_static )
 
-my_find_package( LIBVORBIS vorbis/vorbisfile.h vorbis libvorbis libvorbis_static )
-if(WIN32)
-	find_library( temp NAMES libvorbisfile libvorbisfile_static PATHS $ENV{LIBVORBIS_LIBRARYDIR})
-	set( LIBVORBIS_LIBRARIES ${LIBVORBIS_LIBRARIES} ${temp} )
-else()
-	set( LIBVORBIS_LIBRARIES ${LIBVORBIS_LIBRARIES} vorbisfile )
-endif()
+my_find_package( LIBVORBIS vorbis/vorbisfile.h vorbis ${VORBISFILE_LIBRARY_NAMES} )
+my_find_package( LIBVORBISFILE "" vorbisfile vorbisfile_static )
+set(LIBVORBIS_LIBRARIES ${LIBVORBIS_LIBRARY} ${LIBVORBISFILE_LIBRARY})
 
-my_find_package( ZLIB zlib.h z zdll zlib )
+my_find_package( ZLIB zlib.h z zdll zlib zlibd)
 
 my_find_package( PNG png.h png libpng16 libpng16_static libpng16d libpng16_staticd )
 

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -1,0 +1,57 @@
+cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+project(Reaping2_DEPS)
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/../cmake_support)
+
+set(EXTERNALS_WORK_DIR ${PROJECT_BINARY_DIR}/externals)
+
+if(REAPING2_DEPS_INSTALL_DIR)
+    set(EXTERNALS_INSTALL_DIR ${REAPING2_DEPS_INSTALL_DIR})
+else()
+    set(EXTERNALS_INSTALL_DIR ${PROJECT_SOURCE_DIR}/../local)
+endif()
+message(STATUS "Setting staging dir for ${PROJECT_NAME}: ${EXTERNALS_INSTALL_DIR}")
+
+if(UNIX)
+    set(PLATFORM_CMAKE_ARGS "-DCMAKE_INSTALL_RPATH=${EXERNALS_INSTALL_DIR}/lib")
+endif(UNIX)
+
+# Most often we want to build everything on Windows, but not on Linux. It can
+# be still overridden by specifying the -DUSE_BUNDLED_DEFAULT option with the
+# cmake command.
+if(WIN32)
+    set(DEFAULT_ENABLED_BUNDLED_DEPS ON)
+else()
+    set(DEFAULT_ENABLED_BUNDLED_DEPS OFF)
+endif()
+
+option(USE_BUNDLED_DEFAULT
+        "Set default option value for bundled dependencies"
+        ${DEFAULT_ENABLED_BUNDLED_DEPS})
+
+# Shorthand for declaring an option and adding a subdirectory if option is on
+macro(ADD_BUNDLED_DEPENDENCY NAME)
+    string(TOUPPER ${NAME} NAME_UPPER)
+
+    option(USE_BUNDLED_${NAME_UPPER}
+        "Use bundled ${name}"
+        ${USE_BUNDLED_DEFAULT})
+
+    if(USE_BUNDLED_${NAME_UPPER})
+        message(STATUS "Adding external: ${NAME}")
+        add_subdirectory(${NAME})
+    endif()
+endmacro(ADD_BUNDLED_DEPENDENCY)
+
+include(ExternalProject)
+
+add_bundled_dependency(boost)
+add_bundled_dependency(glew)
+add_bundled_dependency(glfw)
+add_bundled_dependency(glm)
+add_bundled_dependency(libogg)
+add_bundled_dependency(libvorbis)
+add_bundled_dependency(zlib)
+add_bundled_dependency(libpng)
+add_bundled_dependency(portaudio)
+add_bundled_dependency(enet)

--- a/deps/boost/CMakeLists.txt
+++ b/deps/boost/CMakeLists.txt
@@ -1,0 +1,74 @@
+set(BOOST_URL
+        "http://downloads.sourceforge.net/project/boost/boost/1.60.0/boost_1_60_0.tar.gz"
+        CACHE STRING "Location of boost source package")
+
+if(WIN32)
+    set(BOOST_BOOTSTRAP_CMD bootstrap.bat)
+    set(BOOST_BUILD_CMD b2)
+    if("v90" STREQUAL "${CMAKE_GENERATOR_TOOLSET}")
+        set(BOOST_TOOLSET_ARG "--toolset=msvc-9.0")
+    elseif("v100" STREQUAL "${CMAKE_GENERATOR_TOOLSET}")
+        set(BOOST_TOOLSET_ARG "--toolset=msvc-10.0")
+    elseif("v110" STREQUAL "${CMAKE_GENERATOR_TOOLSET}")
+        set(BOOST_TOOLSET_ARG "--toolset=msvc-11.0")
+    elseif("v120" STREQUAL "${CMAKE_GENERATOR_TOOLSET}")
+        set(BOOST_TOOLSET_ARG "--toolset=msvc-12.0")
+    elseif("v140" STREQUAL "${CMAKE_GENERATOR_TOOLSET}")
+        set(BOOST_TOOLSET_ARG "--toolset=msvc-14.0")
+    endif()
+else(WIN32)
+    set(BOOST_BOOTSTRAP_CMD ./bootstrap.sh)
+    set(BOOST_BUILD_CMD ./b2)
+    set(BOOST_RPATH_ARG "dll-path=${EXTERNALS_INSTALL_DIR}/lib")
+endif(WIN32)
+
+if(NOT DEFINED BOOST_ADDRESS_MODEL)
+    # This script does not handle all cases on all platforms,
+    # but what could possibly go wrong anyway
+
+    include(ArchDetect)
+
+    detect_architecture(COMPILERARCH)
+    string(LENGTH ${COMPILERARCH} ARCHSTRLEN)
+    math(EXPR SUBSTRBEGIN ${ARCHSTRLEN}-2)
+    string(SUBSTRING ${COMPILERARCH} ${SUBSTRBEGIN} 2 ARCH_END)
+
+    if("64" STREQUAL "${ARCH_END}")
+        set(BOOST_ADDRESS_MODEL_ARG "address-model=64")
+    else()
+        set(BOOST_ADDRESS_MODEL_ARG "address-model=32")
+    endif()
+else()
+    set(BOOST_ADDRESS_MODEL_ARG "address-model=${BOOST_ADDRESS_MODEL}")
+endif()
+
+
+ExternalProject_Add(ext_boost
+        PREFIX "${EXTERNALS_WORK_DIR}"
+        SOURCE_DIR "${EXTERNALS_WORK_DIR}/src/boost"
+        INSTALL_DIR "${EXTERNALS_INSTALL_DIR}"
+        URL "${BOOST_URL}"
+        URL_MD5 "28f58b9a33469388302110562bdf6188"
+        BUILD_IN_SOURCE 1
+        CONFIGURE_COMMAND ${BOOST_BOOTSTRAP_CMD}
+        BUILD_COMMAND ${BOOST_BUILD_CMD}
+                        --build-dir="${EXTERNALS_WORK_DIR}/build/boost"
+                        --with-filesystem
+                        --with-system
+                        --with-exception
+                        --with-system
+                        --with-thread
+                        --with-date_time
+                        --with-program_options
+                        --with-atomic
+                        --with-serialization
+                        --with-chrono
+                        --build-dir=${EXTERNALS_WORK_DIR}/build/boost
+                        --prefix=${EXTERNALS_INSTALL_DIR}
+                        --includedir=${EXTERNALS_INSTALL_DIR}/include
+                        ${BOOST_ADDRESS_MODEL_ARG}
+                        ${BOOST_TOOLSET_ARG}
+                        ${BOOST_RPATH_ARG}
+                        install
+        INSTALL_COMMAND "")
+

--- a/deps/enet/CMakeLists.txt
+++ b/deps/enet/CMakeLists.txt
@@ -1,0 +1,32 @@
+set(ENET_URL
+        "http://enet.bespin.org/download/enet-1.3.13.tar.gz"
+        CACHE STRING "Location of enet source package")
+
+set(ENET_LIBRARY ${CMAKE_STATIC_LIBRARY_PREFIX}enet${CMAKE_STATIC_LIBRARY_SUFFIX})
+
+ExternalProject_Add(ext_enet
+        PREFIX "${EXTERNALS_WORK_DIR}"
+        SOURCE_DIR "${EXTERNALS_WORK_DIR}/src/enet"
+        BINARY_DIR "${EXTERNALS_WORK_DIR}/build/enet"
+        INSTALL_DIR "${EXTERNALS_INSTALL_DIR}"
+        URL "${ENET_URL}"
+        URL_MD5 b83b9a7791417b6b6f5c68231f6e218b
+        CMAKE_ARGS
+            ${PLATFORM_CMAKE_ARGS}
+            -G ${CMAKE_GENERATOR}
+            -DCMAKE_INSTALL_PREFIX=${EXTERNALS_INSTALL_DIR}
+            -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+            -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG=${PROJECT_BINARY_DIR}
+            -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=${EXTERNALS_WORK_DIR}/build/enet
+            -DCMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG=${EXTERNALS_WORK_DIR}/build/enet
+            -DCMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE=${EXTERNALS_WORK_DIR}/build/enet
+            -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG=${EXTERNALS_WORK_DIR}/build/enet
+            -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE=${EXTERNALS_WORK_DIR}/build/enet
+        INSTALL_COMMAND
+            COMMAND ${CMAKE_COMMAND} -E copy
+                ${EXTERNALS_WORK_DIR}/build/enet/${ENET_LIBRARY}
+                ${EXTERNALS_INSTALL_DIR}/lib/${ENET_LIBRARY}
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+                ${EXTERNALS_WORK_DIR}/src/enet/include/enet
+                ${EXTERNALS_INSTALL_DIR}/include/enet)
+

--- a/deps/glew/CMakeLists.txt
+++ b/deps/glew/CMakeLists.txt
@@ -1,0 +1,24 @@
+set(GLEW_URL
+        "https://sourceforge.net/projects/glew/files/glew/1.13.0/glew-1.13.0.tgz/download"
+        CACHE STRING "Location of glew source package")
+
+add_custom_target(ext_glew_patch
+        SOURCES glew_cmakelists.txt.in)
+
+ExternalProject_Add(ext_glew
+        PREFIX "${EXTERNALS_WORK_DIR}"
+        SOURCE_DIR "${EXTERNALS_WORK_DIR}/src/glew"
+        BINARY_DIR "${EXTERNALS_WORK_DIR}/build/glew"
+        INSTALL_DIR "${EXTERNALS_INSTALL_DIR}"
+        URL "${GLEW_URL}"
+        URL_MD5 "7cbada3166d2aadfc4169c4283701066"
+        PATCH_COMMAND
+            COMMAND ${CMAKE_COMMAND} -E copy
+                    ${CMAKE_CURRENT_SOURCE_DIR}/glew_cmakelists.txt.in
+                    ${EXTERNALS_WORK_DIR}/src/glew/CMakeLists.txt
+        CMAKE_ARGS
+            ${PLATFORM_CMAKE_ARGS}
+            -G ${CMAKE_GENERATOR}
+            -DCMAKE_INSTALL_PREFIX=${EXTERNALS_INSTALL_DIR}
+            -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+            -DBUILD_UTILS=off)

--- a/deps/glew/glew_cmakelists.txt.in
+++ b/deps/glew/glew_cmakelists.txt.in
@@ -1,0 +1,130 @@
+if ( NOT DEFINED CMAKE_BUILD_TYPE )
+  set( CMAKE_BUILD_TYPE Release CACHE STRING "Build type" )
+endif ()
+
+project (glew)
+
+cmake_minimum_required (VERSION 2.4)
+
+if (COMMAND cmake_policy)
+  cmake_policy (SET CMP0003 NEW)
+endif()
+
+set(CMAKE_DEBUG_POSTFIX d)
+
+option (BUILD_UTILS "utilities" ON)
+
+set (GLEW_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+# get version from config/version
+file (STRINGS ${GLEW_DIR}/config/version  _VERSION_MAJOR_STRING REGEX "GLEW_MAJOR[ ]*=[ ]*[0-9]+.*")
+string (REGEX REPLACE "GLEW_MAJOR[ ]*=[ ]*([0-9]+)" "\\1" CPACK_PACKAGE_VERSION_MAJOR ${_VERSION_MAJOR_STRING})
+file (STRINGS ${GLEW_DIR}/config/version  _VERSION_MINOR_STRING REGEX "GLEW_MINOR[ ]*=[ ]*[0-9]+.*")
+string (REGEX REPLACE "GLEW_MINOR[ ]*=[ ]*([0-9]+)" "\\1" CPACK_PACKAGE_VERSION_MINOR ${_VERSION_MINOR_STRING})
+file (STRINGS ${GLEW_DIR}/config/version  _VERSION_PATCH_STRING REGEX "GLEW_MICRO[ ]*=[ ]*[0-9]+.*")
+string (REGEX REPLACE "GLEW_MICRO[ ]*=[ ]*([0-9]+)" "\\1" CPACK_PACKAGE_VERSION_PATCH ${_VERSION_PATCH_STRING})
+set (GLEW_VERSION ${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH})
+
+set (CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+if (WIN32)
+  set (GLEW_LIB_NAME glew32)
+else ()
+  set (GLEW_LIB_NAME GLEW)
+  set (DLL_PREFIX lib)
+endif ()
+
+find_package (OpenGL REQUIRED)
+set (GLEW_LIBRARIES ${OPENGL_LIBRARIES})
+
+add_definitions (-DGLEW_NO_GLU)
+
+include_directories (${GLEW_DIR}/include)
+
+add_library (glew SHARED ${GLEW_DIR}/src/glew.c)
+set_target_properties (glew PROPERTIES COMPILE_DEFINITIONS "GLEW_BUILD" OUTPUT_NAME "${GLEW_LIB_NAME}" PREFIX "${DLL_PREFIX}")
+add_library (glew_s STATIC ${GLEW_DIR}/src/glew.c)
+set_target_properties (glew_s PROPERTIES COMPILE_DEFINITIONS "GLEW_STATIC" OUTPUT_NAME "${GLEW_LIB_NAME}s")
+target_link_libraries (glew ${GLEW_LIBRARIES})
+target_link_libraries (glew_s ${GLEW_LIBRARIES})
+
+add_library(glewmx SHARED ${GLEW_DIR}/src/glew.c )
+set_target_properties (glewmx PROPERTIES COMPILE_DEFINITIONS "GLEW_BUILD;GLEW_MX" OUTPUT_NAME "${GLEW_LIB_NAME}mx" PREFIX "${DLL_PREFIX}")
+add_library(glewmx_s STATIC ${GLEW_DIR}/src/glew.c )
+set_target_properties (glewmx_s PROPERTIES COMPILE_DEFINITIONS "GLEW_STATIC;GLEW_MX" OUTPUT_NAME "${GLEW_LIB_NAME}mxs")
+target_link_libraries (glewmx ${GLEW_LIBRARIES})
+target_link_libraries (glewmx_s ${GLEW_LIBRARIES})
+
+if(CMAKE_VERSION VERSION_LESS 2.8.12)
+  set(MAYBE_EXPORT "")
+else()
+  target_compile_definitions(glew_s INTERFACE "GLEW_STATIC")
+  target_compile_definitions(glewmx INTERFACE "GLEW_MX")
+  target_compile_definitions(glewmx_s INTERFACE "GLEW_STATIC;GLEW_MX")
+  foreach(t glew glew_s glewmx glewmx_s)
+    target_include_directories(${t} PUBLIC $<INSTALL_INTERFACE:include>)
+  endforeach()
+  set(MAYBE_EXPORT EXPORT glew-targets)
+endif()
+
+set(targets_to_install "")
+if(NOT DEFINED BUILD_SHARED_LIBS OR BUILD_SHARED_LIBS)
+  list(APPEND targets_to_install glew glewmx)
+endif()
+
+if(NOT DEFINED BUILD_SHARED_LIBS OR NOT BUILD_SHARED_LIBS)
+  list(APPEND targets_to_install glew_s glewmx_s)
+endif()
+
+install ( TARGETS ${targets_to_install}
+          ${MAYBE_EXPORT}
+          RUNTIME DESTINATION bin
+          LIBRARY DESTINATION lib${LIB_SUFFIX}
+          ARCHIVE DESTINATION lib${LIB_SUFFIX}
+)
+
+if (BUILD_UTILS)
+  add_executable (glewinfo ${GLEW_DIR}/src/glewinfo.c)
+  target_link_libraries (glewinfo glew)
+
+  add_executable (visualinfo ${GLEW_DIR}/src/visualinfo.c)
+  target_link_libraries (visualinfo glew)
+
+  install ( TARGETS glewinfo visualinfo
+            DESTINATION bin)
+endif ()
+
+set (prefix ${CMAKE_INSTALL_PREFIX})
+set (exec_prefix \${prefix})
+set (libdir \${prefix}/lib)
+set (includedir \${prefix}/include)
+set (includedir \${prefix}/include)
+set (version ${GLEW_VERSION})
+set (libname ${GLEW_LIB_NAME})
+set (cflags)
+set (requireslib glu)
+configure_file (${GLEW_DIR}/glew.pc.in ${GLEW_DIR}/glew.pc @ONLY)
+set (cflags "-DGLEW_MX")
+set (libname ${GLEW_LIB_NAME}mx)
+configure_file (${GLEW_DIR}/glew.pc.in ${GLEW_DIR}/glewmx.pc @ONLY)
+
+install(FILES ${GLEW_DIR}/glew.pc ${GLEW_DIR}/glewmx.pc
+        DESTINATION lib/pkgconfig
+)
+
+install (FILES
+    ${GLEW_DIR}/include/GL/wglew.h
+    ${GLEW_DIR}/include/GL/glew.h
+    ${GLEW_DIR}/include/GL/glxew.h
+    DESTINATION include/GL)
+
+if(MAYBE_EXPORT)
+  install(EXPORT glew-targets DESTINATION lib/cmake/glew
+    NAMESPACE GLEW::)
+  install(FILES
+      ${CMAKE_CURRENT_SOURCE_DIR}/build/cmake/glew-config.cmake
+      ${CMAKE_CURRENT_SOURCE_DIR}/build/cmake/CopyImportedTargetProperties.cmake
+    DESTINATION lib/cmake/glew)
+endif()

--- a/deps/glfw/CMakeLists.txt
+++ b/deps/glfw/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(GLFW_URL
+        "http://sourceforge.net/projects/glfw/files/glfw/3.0.4/glfw-3.0.4.tar.gz/download"
+        CACHE STRING "Location of glfw source package")
+
+ExternalProject_Add(ext_glfw
+        PREFIX "${EXTERNALS_WORK_DIR}"
+        SOURCE_DIR "${EXTERNALS_WORK_DIR}/src/glfw"
+        BINARY_DIR "${EXTERNALS_WORK_DIR}/build/glfw"
+        INSTALL_DIR "${EXTERNALS_INSTALL_DIR}"
+        URL "${GLFW_URL}"
+        URL_MD5 "1e82fdefb1b0df2727cce116d21cd8af"
+        CMAKE_ARGS
+            ${PLATFORM_CMAKE_ARGS}
+            -G ${CMAKE_GENERATOR}
+            -DCMAKE_INSTALL_PREFIX=${EXTERNALS_INSTALL_DIR}
+            -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+

--- a/deps/glm/CMakeLists.txt
+++ b/deps/glm/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(GLM_URL
+        "https://github.com/g-truc/glm/archive/0.9.7.2.tar.gz"
+        CACHE STRING "Location of glm source package")
+
+ExternalProject_Add(ext_glm
+        PREFIX "${EXTERNALS_WORK_DIR}"
+        SOURCE_DIR "${EXTERNALS_WORK_DIR}/src/glm"
+        BINARY_DIR "${EXTERNALS_WORK_DIR}/build/glm"
+        INSTALL_DIR "${EXTERNALS_INSTALL_DIR}"
+        URL "${GLM_URL}"
+        URL_MD5 "e1aa3fdbbbe0edc924165cc5f0bc24f6"
+        CMAKE_ARGS
+            ${PLATFORM_CMAKE_ARGS}
+            -G ${CMAKE_GENERATOR}
+            -DCMAKE_INSTALL_PREFIX=${EXTERNALS_INSTALL_DIR}
+            -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+

--- a/deps/libogg/CMakeLists.txt
+++ b/deps/libogg/CMakeLists.txt
@@ -1,0 +1,27 @@
+set(LIBOGG_URL
+        "http://downloads.xiph.org/releases/ogg/libogg-1.3.2.tar.gz"
+        CACHE STRING "Location of libogg source package")
+
+add_custom_target(ext_libogg_patch
+        SOURCES libogg_cmakelists.txt.in FindOgg.cmake)
+
+ExternalProject_Add(ext_libogg
+        PREFIX "${EXTERNALS_WORK_DIR}"
+        SOURCE_DIR "${EXTERNALS_WORK_DIR}/src/libogg"
+        BINARY_DIR "${EXTERNALS_WORK_DIR}/build/libogg"
+        INSTALL_DIR "${EXTERNALS_INSTALL_DIR}"
+        URL "${LIBOGG_URL}"
+        URL_HASH SHA256=e19ee34711d7af328cb26287f4137e70630e7261b17cbe3cd41011d73a654692
+        PATCH_COMMAND
+            COMMAND ${CMAKE_COMMAND} -E copy
+                    ${CMAKE_CURRENT_SOURCE_DIR}/libogg_cmakelists.txt.in
+                    ${EXTERNALS_WORK_DIR}/src/libogg/CMakeLists.txt
+            COMMAND ${CMAKE_COMMAND} -E copy
+                    ${CMAKE_CURRENT_SOURCE_DIR}/FindOgg.cmake
+                    ${EXTERNALS_WORK_DIR}/src/libogg/FindOgg.cmake
+        CMAKE_ARGS
+            ${PLATFORM_CMAKE_ARGS}
+            -G ${CMAKE_GENERATOR}
+            -DCMAKE_INSTALL_PREFIX=${EXTERNALS_INSTALL_DIR}
+            -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+

--- a/deps/libogg/FindOgg.cmake
+++ b/deps/libogg/FindOgg.cmake
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 2.8)
+
+find_path(OGG_INCLUDE_DIR ogg/ogg.h)
+
+set(OGG_NAMES ${OGG_NAMES} ogg libogg)
+find_library(OGG_LIBRARY NAMES ${OGG_NAMES} PATH)
+
+if(OGG_INCLUDE_DIR AND OGG_LIBRARY)
+    set(OGG_FOUND TRUE)
+endif()
+
+if(OGG_FOUND)
+    if(NOT Ogg_FIND_QUIETLY)
+        message(STATUS "Found Ogg: ${OGG_LIBRARY}")
+    endif()
+else(OGG_FOUND)
+    if(Ogg_FIND_REQUIRED)
+        message(FATAL_ERROR "Could not find ogg")
+    endif()
+endif()

--- a/deps/libogg/libogg_cmakelists.txt.in
+++ b/deps/libogg/libogg_cmakelists.txt.in
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(Ogg C)
+
+set(src
+        src/bitwise.c
+        src/framing.c
+)
+set(hdr
+        include/ogg/ogg.h
+        include/ogg/os_types.h
+)
+
+if(MSVC)
+    ADD_DEFINITIONS(/DLIBOGG_EXPORTS /D_UNICODE /DUNICODE)
+    LIST(APPEND src win32/ogg.def)
+endif(MSVC)
+
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+add_library(ogg SHARED ${src} ${hdr})
+
+if(UNIX AND NOT APPLE)
+    # Gotta generate ogg/config_types.h
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/include/ogg/config_types.h
+        COMMAND ./configure --silent
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+    add_custom_target(config_types SOURCES include/ogg/config_types.h)
+    add_dependencies(ogg config_types)
+
+    install(FILES include/ogg/config_types.h DESTINATION include/ogg)
+
+endif(UNIX AND NOT APPLE)
+
+install(TARGETS ogg
+        RUNTIME DESTINATION bin
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib)
+
+install(FILES ${hdr} DESTINATION include/ogg)
+
+install(FILES FindOgg.cmake DESTINATION lib/cmake)

--- a/deps/libpng/CMakeLists.txt
+++ b/deps/libpng/CMakeLists.txt
@@ -1,0 +1,21 @@
+set(LIBPNG_URL
+        "http://prdownloads.sourceforge.net/libpng/libpng-1.6.21.tar.gz"
+        CACHE STRING "Location of libpng source package")
+
+ExternalProject_Add(ext_libpng
+        PREFIX "${EXTERNALS_WORK_DIR}"
+        SOURCE_DIR "${EXTERNALS_WORK_DIR}/src/libpng"
+        BINARY_DIR "${EXTERNALS_WORK_DIR}/build/libpng"
+        INSTALL_DIR "${EXTERNALS_INSTALL_DIR}"
+        URL ${LIBPNG_URL}
+        URL_MD5 aca36ec8e0a3b406a5912243bc243717
+        CMAKE_ARGS
+            ${PLATFORM_CMAKE_ARGS}
+            -G ${CMAKE_GENERATOR}
+            -DCMAKE_INSTALL_PREFIX=${EXTERNALS_INSTALL_DIR}
+            -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+
+if(USE_BUNDLED_ZLIB)
+    add_dependencies(ext_libpng ext_zlib)
+endif()
+

--- a/deps/libvorbis/CMakeLists.txt
+++ b/deps/libvorbis/CMakeLists.txt
@@ -1,0 +1,28 @@
+set(LIBVORBIS_URL
+        "http://downloads.xiph.org/releases/vorbis/libvorbis-1.3.5.tar.gz"
+        CACHE STRING "Location of libvorbis source package")
+
+add_custom_target(ext_libvorbis_patch
+        SOURCES libvorbis_cmakelists.txt.in)
+
+ExternalProject_Add(ext_libvorbis
+        PREFIX "${EXTERNALS_WORK_DIR}"
+        SOURCE_DIR "${EXTERNALS_WORK_DIR}/src/libvorbis"
+        BINARY_DIR "${EXTERNALS_WORK_DIR}/build/libvorbis"
+        INSTALL_DIR "${EXTERNALS_INSTALL_DIR}"
+        URL "${LIBVORBIS_URL}"
+        URL_HASH SHA256=6efbcecdd3e5dfbf090341b485da9d176eb250d893e3eb378c428a2db38301ce
+        PATCH_COMMAND ${CMAKE_COMMAND} -E copy
+                ${CMAKE_CURRENT_SOURCE_DIR}/libvorbis_cmakelists.txt.in
+                ${EXTERNALS_WORK_DIR}/src/libvorbis/CMakeLists.txt
+        CMAKE_ARGS
+            ${PLATFORM_CMAKE_ARGS}
+            -G ${CMAKE_GENERATOR}
+            -DCMAKE_INSTALL_PREFIX=${EXTERNALS_INSTALL_DIR}
+            -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+            -DCMAKE_MODULE_PATH=${EXTERNALS_INSTALL_DIR}/lib/cmake)
+
+if(USE_BUNDLED_LIBOGG)
+    add_dependencies(ext_libvorbis ext_libogg)
+endif()
+

--- a/deps/libvorbis/libvorbis_cmakelists.txt.in
+++ b/deps/libvorbis/libvorbis_cmakelists.txt.in
@@ -1,0 +1,87 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(LIBVORBIS C)
+
+find_package(Ogg REQUIRED)
+
+include_directories(
+        ${OGG_INCLUDE_DIR}
+        ${PROJECT_SOURCE_DIR}/lib)
+
+set(src
+        lib/analysis.c
+        lib/barkmel.c
+        lib/bitrate.c
+        lib/block.c
+        lib/codebook.c
+        lib/envelope.c
+        lib/floor0.c
+        lib/floor1.c
+        lib/info.c
+        lib/lookup.c
+        lib/lpc.c
+        lib/lsp.c
+        lib/mapping0.c
+        lib/mdct.c
+        lib/psy.c
+        #lib/psytune.c
+        lib/registry.c
+        lib/res0.c
+        lib/sharedbook.c
+        lib/smallft.c
+        lib/synthesis.c
+        #lib/tone.c
+        lib/vorbisenc.c
+        lib/window.c
+)
+
+set(hdr
+        lib/backends.h
+        lib/bitrate.h
+        lib/codebook.h
+        lib/codec_internal.h
+        lib/envelope.h
+        lib/highlevel.h
+        lib/lookup.h
+        lib/lookup_data.h
+        lib/lpc.h
+        lib/lsp.h
+        lib/masking.h
+        lib/mdct.h
+        lib/misc.h
+        lib/os.h
+        lib/psy.h
+        lib/registry.h
+        lib/scales.h
+        lib/smallft.h
+        lib/window.h
+)
+
+if(WIN32)
+    set(vorbis_defs win32/vorbis.def)
+    set(vorbisfile_defs win32/vorbisfile.def)
+endif()
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+add_library(vorbis SHARED ${src} ${hdr} ${vorbis_defs})
+add_library(vorbisfile SHARED lib/vorbisfile.c ${vorbisfile_defs})
+add_library(vorbisfile_static STATIC lib/vorbisfile.c ${vorbisfile_defs})
+
+if(UNIX)
+    set(PLATFORM_LIBS m)
+endif(UNIX)
+target_link_libraries(vorbis ${OGG_LIBRARY} ${PLATFORM_LIBS})
+target_link_libraries(vorbisfile vorbis ${OGG_LIBRARY})
+if(NOT WIN32)
+    set_target_properties(vorbisfile_static PROPERTIES OUTPUT_NAME vorbisfile)
+endif(NOT WIN32)
+
+install(TARGETS vorbis vorbisfile
+        RUNTIME DESTINATION bin
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib)
+
+install(DIRECTORY include/vorbis
+        DESTINATION include
+        FILES_MATCHING PATTERN "*.h")

--- a/deps/portaudio/CMakeLists.txt
+++ b/deps/portaudio/CMakeLists.txt
@@ -1,0 +1,30 @@
+set(PORTAUDIO_URL
+        "https://subversion.assembla.com/svn/portaudio/portaudio/trunk"
+        CACHE STRING "Location of portaudio svn repository")
+
+# Rev. 1944 contains fix for:
+#   https://www.assembla.com/spaces/portaudio/tickets/228-ksguid-lib-linker-issues
+set(PORTAUDIO_REV
+        "1944"
+        CACHE STRING "Portaudio svn revision to check out")
+
+add_custom_target(ext_portaudio_patch
+        SOURCES portaudio_cmakelists.txt.in)
+
+ExternalProject_Add(ext_portaudio
+        PREFIX "${EXTERNALS_WORK_DIR}"
+        SOURCE_DIR "${EXTERNALS_WORK_DIR}/src/portaudio"
+        BINARY_DIR "${EXTERNALS_WORK_DIR}/build/portaudio"
+        INSTALL_DIR "${EXTERNALS_INSTALL_DIR}"
+        SVN_REPOSITORY ${PORTAUDIO_URL}
+        SVN_REVISION -r ${PORTAUDIO_REV}
+        UPDATE_COMMAND ""
+        PATCH_COMMAND ${CMAKE_COMMAND} -E copy
+                ${CMAKE_CURRENT_SOURCE_DIR}/portaudio_cmakelists.txt.in
+                ${EXTERNALS_WORK_DIR}/src/portaudio/CMakeLists.txt
+        CMAKE_ARGS
+            ${PLATFORM_CMAKE_ARGS}
+            -G ${CMAKE_GENERATOR}
+            -DCMAKE_INSTALL_PREFIX=${EXTERNALS_INSTALL_DIR}
+            -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+

--- a/deps/portaudio/portaudio_cmakelists.txt.in
+++ b/deps/portaudio/portaudio_cmakelists.txt.in
@@ -1,0 +1,368 @@
+# $Id: $
+#
+# For a "How-To" please refer to the Portaudio documentation at:
+# http://www.portaudio.com/trac/wiki/TutorialDir/Compile/CMake
+#
+PROJECT( portaudio )
+
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+
+OPTION(PA_CONFIG_LIB_OUTPUT_PATH "Make sure that output paths are kept neat" OFF)
+IF(CMAKE_CL_64)
+SET(TARGET_POSTFIX x64)
+IF(PA_CONFIG_LIB_OUTPUT_PATH)
+SET(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/bin/x64)
+ENDIF(PA_CONFIG_LIB_OUTPUT_PATH)
+ELSE(CMAKE_CL_64)
+SET(TARGET_POSTFIX x86)
+IF(PA_CONFIG_LIB_OUTPUT_PATH)
+SET(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/bin/Win32)
+ENDIF(PA_CONFIG_LIB_OUTPUT_PATH)
+ENDIF(CMAKE_CL_64)
+
+OPTION(PA_ENABLE_DEBUG_OUTPUT "Enable debug output for Portaudio" OFF)
+IF(PA_ENABLE_DEBUG_OUTPUT)
+ADD_DEFINITIONS(-DPA_ENABLE_DEBUG_OUTPUT)
+ENDIF(PA_ENABLE_DEBUG_OUTPUT)
+
+IF(WIN32 AND MSVC)
+OPTION(PA_DLL_LINK_WITH_STATIC_RUNTIME "Link with static runtime libraries (minimizes runtime dependencies)" ON)
+IF(PA_DLL_LINK_WITH_STATIC_RUNTIME)
+  FOREACH(flag_var
+        CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
+        CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
+        CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+        CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+    IF(${flag_var} MATCHES "/MD")
+      STRING(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+    ENDIF(${flag_var} MATCHES "/MD")
+  ENDFOREACH(flag_var)
+ENDIF(PA_DLL_LINK_WITH_STATIC_RUNTIME)
+
+ENDIF(WIN32 AND MSVC)
+
+IF(WIN32)
+OPTION(PA_UNICODE_BUILD "Enable Portaudio Unicode build" ON)
+
+SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake_support)
+# Try to find DirectX SDK
+FIND_PACKAGE(DXSDK)
+# Try to find ASIO SDK (assumes that portaudio and asiosdk folders are side-by-side, see
+# http://www.portaudio.com/trac/wiki/TutorialDir/Compile/WindowsASIOMSVC)
+FIND_PACKAGE(ASIOSDK)
+
+IF(ASIOSDK_FOUND)
+OPTION(PA_USE_ASIO "Enable support for ASIO" ON)
+ELSE(ASIOSDK_FOUND)
+OPTION(PA_USE_ASIO "Enable support for ASIO" OFF)
+ENDIF(ASIOSDK_FOUND)
+IF(DXSDK_FOUND)
+OPTION(PA_USE_DS "Enable support for DirectSound" ON)
+ELSE(DXSDK_FOUND)
+OPTION(PA_USE_DS "Enable support for DirectSound" OFF)
+ENDIF(DXSDK_FOUND)
+OPTION(PA_USE_WMME "Enable support for MME" ON)
+OPTION(PA_USE_WASAPI "Enable support for WASAPI" ON)
+OPTION(PA_USE_WDMKS "Enable support for WDMKS" ON)
+OPTION(PA_USE_WDMKS_DEVICE_INFO "Use WDM/KS API for device info" ON)
+MARK_AS_ADVANCED(PA_USE_WDMKS_DEVICE_INFO)
+IF(PA_USE_DS)
+OPTION(PA_USE_DIRECTSOUNDFULLDUPLEXCREATE "Use DirectSound full duplex create" ON)
+MARK_AS_ADVANCED(PA_USE_DIRECTSOUNDFULLDUPLEXCREATE)
+ENDIF(PA_USE_DS)
+ENDIF(WIN32)
+
+# Set variables for DEF file expansion
+IF(NOT PA_USE_ASIO)
+SET(DEF_EXCLUDE_ASIO_SYMBOLS ";")
+ENDIF(NOT PA_USE_ASIO)
+
+IF(NOT PA_USE_WASAPI)
+SET(DEF_EXCLUDE_WASAPI_SYMBOLS ";")
+ENDIF(NOT PA_USE_WASAPI)
+
+IF(PA_USE_WDMKS_DEVICE_INFO)
+ADD_DEFINITIONS(-DPAWIN_USE_WDMKS_DEVICE_INFO)
+ENDIF(PA_USE_WDMKS_DEVICE_INFO)
+
+IF(PA_USE_DIRECTSOUNDFULLDUPLEXCREATE)
+ADD_DEFINITIONS(-DPAWIN_USE_DIRECTSOUNDFULLDUPLEXCREATE)
+ENDIF(PA_USE_DIRECTSOUNDFULLDUPLEXCREATE)
+
+#######################################
+IF(WIN32)
+INCLUDE_DIRECTORIES(src/os/win)
+ENDIF(WIN32)
+
+IF(PA_USE_ASIO)
+INCLUDE_DIRECTORIES(${ASIOSDK_ROOT_DIR}/common)
+INCLUDE_DIRECTORIES(${ASIOSDK_ROOT_DIR}/host)
+INCLUDE_DIRECTORIES(${ASIOSDK_ROOT_DIR}/host/pc)
+
+SET(PA_ASIO_INCLUDES
+  include/pa_asio.h
+)
+
+SET(PA_ASIO_SOURCES
+  src/hostapi/asio/pa_asio.cpp
+)
+
+SET(PA_ASIOSDK_SOURCES
+  ${ASIOSDK_ROOT_DIR}/common/asio.cpp
+  ${ASIOSDK_ROOT_DIR}/host/pc/asiolist.cpp
+  ${ASIOSDK_ROOT_DIR}/host/asiodrivers.cpp
+)
+
+SOURCE_GROUP("hostapi\\ASIO" FILES
+  ${PA_ASIO_SOURCES}
+)
+
+SOURCE_GROUP("hostapi\\ASIO\\ASIOSDK" FILES
+  ${PA_ASIOSDK_SOURCES}
+)
+ENDIF(PA_USE_ASIO)
+
+IF(PA_USE_DS)
+INCLUDE_DIRECTORIES(${DXSDK_INCLUDE_DIR})
+INCLUDE_DIRECTORIES(src/os/win)
+
+SET(PA_DS_INCLUDES
+  include/pa_win_ds.h
+  src/hostapi/dsound/pa_win_ds_dynlink.h
+)
+
+SET(PA_DS_SOURCES
+  src/hostapi/dsound/pa_win_ds.c
+  src/hostapi/dsound/pa_win_ds_dynlink.c
+)
+
+SOURCE_GROUP("hostapi\\dsound" FILES
+  ${PA_DS_INCLUDES}
+  ${PA_DS_SOURCES}
+)
+ENDIF(PA_USE_DS)
+
+IF(PA_USE_WMME)
+
+SET(PA_WMME_INCLUDES
+  include/pa_win_wmme.h
+)
+
+SET(PA_WMME_SOURCES
+  src/hostapi/wmme/pa_win_wmme.c
+)
+
+SOURCE_GROUP("hostapi\\wmme" FILES
+  ${PA_WMME_SOURCES}
+)
+ENDIF(PA_USE_WMME)
+
+IF(PA_USE_WASAPI)
+
+SET(PA_WASAPI_INCLUDES
+  include/pa_win_wasapi.h
+)
+
+SET(PA_WASAPI_SOURCES
+  src/hostapi/wasapi/pa_win_wasapi.c
+)
+
+SOURCE_GROUP("hostapi\\wasapi" FILES
+  ${PA_WASAPI_SOURCES}
+)
+ENDIF(PA_USE_WASAPI)
+
+IF(PA_USE_WDMKS)
+
+SET(PA_WDMKS_INCLUDES
+  include/pa_win_wdmks.h
+)
+
+SET(PA_WDMKS_SOURCES
+  src/hostapi/wdmks/pa_win_wdmks.c
+)
+
+SOURCE_GROUP("hostapi\\wdmks" FILES
+  ${PA_WDMKS_SOURCES}
+)
+ENDIF(PA_USE_WDMKS)
+
+SET(PA_SKELETON_SOURCES
+  src/hostapi/skeleton/pa_hostapi_skeleton.c
+)
+
+SOURCE_GROUP("hostapi\\skeleton"
+  ${PA_SKELETON_SOURCES})
+
+#######################################
+IF(WIN32)
+SET(PA_INCLUDES
+  include/portaudio.h
+  ${PA_ASIO_INCLUDES}
+  ${PA_DS_INCLUDES}
+  ${PA_WMME_INCLUDES}
+  ${PA_WASAPI_INCLUDES}
+  ${PA_WDMKS_INCLUDES}
+)
+ENDIF(WIN32)
+
+SOURCE_GROUP("include" FILES
+  ${PA_INCLUDES}
+)
+
+SET(PA_COMMON_INCLUDES
+  src/common/pa_allocation.h
+  src/common/pa_converters.h
+  src/common/pa_cpuload.h
+  src/common/pa_debugprint.h
+  src/common/pa_dither.h
+  src/common/pa_endianness.h
+  src/common/pa_hostapi.h
+  src/common/pa_memorybarrier.h
+  src/common/pa_process.h
+  src/common/pa_ringbuffer.h
+  src/common/pa_stream.h
+  src/common/pa_trace.h
+  src/common/pa_types.h
+  src/common/pa_util.h
+)
+
+SET(PA_COMMON_SOURCES
+  src/common/pa_allocation.c
+  src/common/pa_converters.c
+  src/common/pa_cpuload.c
+  src/common/pa_debugprint.c
+  src/common/pa_dither.c
+  src/common/pa_front.c
+  src/common/pa_process.c
+  src/common/pa_ringbuffer.c
+  src/common/pa_stream.c
+  src/common/pa_trace.c
+)
+
+SOURCE_GROUP("common" FILES
+  ${PA_COMMON_INCLUDES}
+  ${PA_COMMON_SOURCES}
+)
+
+SOURCE_GROUP("cmake_generated" FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/portaudio_cmake.def
+  ${CMAKE_CURRENT_BINARY_DIR}/options_cmake.h
+)
+
+IF(WIN32)
+SET(PA_PLATFORM_SOURCES
+  src/os/win/pa_win_hostapis.c
+  src/os/win/pa_win_util.c
+  src/os/win/pa_win_waveformat.c
+  src/os/win/pa_win_wdmks_utils.c
+  src/os/win/pa_win_coinitialize.c
+  src/os/win/pa_x86_plain_converters.c
+)
+
+SOURCE_GROUP("os\\win" FILES
+  ${PA_PLATFORM_SOURCES}
+)
+ELSE(WIN32)
+SET(PA_PLATFORM_SOURCES
+  src/os/unix/pa_unix_hostapis.c
+  src/os/unix/pa_unix_util.c
+)
+ENDIF(WIN32)
+
+INCLUDE_DIRECTORIES( include )
+INCLUDE_DIRECTORIES( src/common )
+
+IF(WIN32 AND MSVC)
+ADD_DEFINITIONS(-D_CRT_SECURE_NO_WARNINGS)
+ENDIF(WIN32 AND MSVC)
+
+ADD_DEFINITIONS(-DPORTAUDIO_CMAKE_GENERATED)
+INCLUDE_DIRECTORIES( ${CMAKE_CURRENT_BINARY_DIR} )
+
+SET(SOURCES_LESS_ASIO_SDK
+  ${PA_COMMON_SOURCES}
+  ${PA_ASIO_SOURCES}
+  ${PA_DS_SOURCES}
+  ${PA_WMME_SOURCES}
+  ${PA_WASAPI_SOURCES}
+  ${PA_WDMKS_SOURCES}
+  ${PA_SKELETON_SOURCES}
+  ${PA_PLATFORM_SOURCES}
+)
+
+IF(PA_UNICODE_BUILD)
+SET_SOURCE_FILES_PROPERTIES(
+  ${SOURCES_LESS_ASIO_SDK}
+  PROPERTIES
+  COMPILE_DEFINITIONS "UNICODE;_UNICODE"
+)
+ENDIF(PA_UNICODE_BUILD)
+
+ADD_LIBRARY(portaudio SHARED
+  ${PA_INCLUDES}
+  ${PA_COMMON_INCLUDES}
+  ${SOURCES_LESS_ASIO_SDK}
+  ${PA_ASIOSDK_SOURCES}
+  ${CMAKE_CURRENT_BINARY_DIR}/portaudio_cmake.def
+  ${CMAKE_CURRENT_BINARY_DIR}/options_cmake.h
+)
+
+ADD_LIBRARY(portaudio_static STATIC
+  ${PA_INCLUDES}
+  ${PA_COMMON_INCLUDES}
+  ${SOURCES_LESS_ASIO_SDK}
+  ${PA_ASIOSDK_SOURCES}
+  ${CMAKE_CURRENT_BINARY_DIR}/options_cmake.h
+)
+
+install(TARGETS portaudio
+        RUNTIME DESTINATION bin
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib)
+install(TARGETS portaudio
+        RUNTIME DESTINATION bin
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib)
+install(DIRECTORY include/
+        DESTINATION include
+        FILES_MATCHING PATTERN "*.h")
+
+# Configure the exports file according to settings
+SET(GENERATED_MESSAGE "CMake generated file, do NOT edit! Use CMake-GUI to change configuration instead.")
+CONFIGURE_FILE( cmake_support/template_portaudio.def ${CMAKE_CURRENT_BINARY_DIR}/portaudio_cmake.def @ONLY )
+# Configure header for options (PA_USE_xxx)
+CONFIGURE_FILE( cmake_support/options_cmake.h.in ${CMAKE_CURRENT_BINARY_DIR}/options_cmake.h @ONLY )
+
+IF(WIN32)
+# If we use DirectSound, we need this for the library to be found (if not in VS project settings)
+IF(PA_USE_DS AND DXSDK_FOUND)
+TARGET_LINK_LIBRARIES(portaudio ${DXSDK_DSOUND_LIBRARY})
+ENDIF(PA_USE_DS AND DXSDK_FOUND)
+
+# If we use WDM/KS we need setupapi.lib
+IF(PA_USE_WDMKS)
+TARGET_LINK_LIBRARIES(portaudio setupapi)
+ENDIF(PA_USE_WDMKS)
+
+SET_TARGET_PROPERTIES(portaudio PROPERTIES OUTPUT_NAME portaudio_${TARGET_POSTFIX})
+SET_TARGET_PROPERTIES(portaudio_static PROPERTIES OUTPUT_NAME portaudio_static_${TARGET_POSTFIX})
+ELSE(WIN32)
+TARGET_LINK_LIBRARIES(portaudio pthread m)
+ENDIF(WIN32)
+
+OPTION(PA_BUILD_TESTS "Include test projects" OFF)
+OPTION(PA_BUILD_EXAMPLES "Include example projects" OFF)
+
+# Prepared for inclusion of test files
+IF(PA_BUILD_TESTS)
+SUBDIRS(test)
+ENDIF(PA_BUILD_TESTS)
+
+# Prepared for inclusion of test files
+IF(PA_BUILD_EXAMPLES)
+SUBDIRS(examples)
+ENDIF(PA_BUILD_EXAMPLES)
+
+#################################
+

--- a/deps/zlib/CMakeLists.txt
+++ b/deps/zlib/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(ZLIB_URL
+        "http://zlib.net/zlib-1.2.8.tar.gz"
+        CACHE STRING "Location of zlib source package")
+
+ExternalProject_Add(ext_zlib
+        PREFIX "${EXTERNALS_WORK_DIR}"
+        SOURCE_DIR "${EXTERNALS_WORK_DIR}/src/zlib"
+        BINARY_DIR "${EXTERNALS_WORK_DIR}/build/zlib"
+        INSTALL_DIR "${EXTERNALS_INSTALL_DIR}"
+        URL "${ZLIB_URL}"
+        URL_MD5 44d667c142d7cda120332623eab69f40
+        CMAKE_ARGS
+            ${PLATFORM_CMAKE_ARGS}
+            -G ${CMAKE_GENERATOR}
+            -DCMAKE_INSTALL_PREFIX=${EXTERNALS_INSTALL_DIR}
+            -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+


### PR DESCRIPTION
This simplifies the handling of external dependencies, especially on platforms where no readily installable packages are available for all of them. 

The `deps/` folder contains a `CMakeLists.txt` with a separate project, which can be built separately from the main one.

Externals can be enabled selectively; the default is to build all of them on Windows, and none of them on Linux. The default enabled state can be also specified as a command line option (`-DUSE_BUNDLED_DEFAULT=off`), and single packages can be toggled as well (e.g. `-DUSE_BUNDLED_BOOST=on`).

All artifacts are installed in a common location, that can be overridden with the `-DREAPING2_DEPS_INSTALL_DIR` variable; by default, it is `deps/../local` (under that there are separate folders for `include/`, `bin/` and `lib/`).

The Reaping2 project also makes use of the `REAPING2_DEPS_INSTALL_DIR` - this location is added to the default search paths used in `my_find_package`.

Tested with the following platforms (building all dependencies & main project using that build result):
- Linux gcc 5.2.1 x64
- Win VC 14.0 x64 (Visual Studio 2015)
- Win VC 14.0 x64 (Visual Studio 2015) with JOM makefiles generator (using Qt Creator)
- Win VC 14.0 x86 (Visual Studio 2015)
- Win VC 11.0 x86 (Visual Studio 2012) with solution generated for Visual Studio 2015

Example build on windows (tip: if you want to build for x64 it has to be specified, by default x86 would be used):

```
[..]\Reaping2> mkdir build-deps; cd build-deps
> cmake ../deps -DREAPING2_DEPS_INSTALL_DIR="C:/local-vc140-x64" -G "Visual Studio 14 2015 Win64"
> cmake --build .
> cd ..; mkdir build; cd build
> cmake .. -DREAPING2_DEPS_INSTALL_DIR="C:/local-vc140-x64"  -G "Visual Studio 14 2015 Win64"
> cmake --build .
```
