### PR TITLE
Explicitly include what we use

### DIFF
--- a/src/platform/memoryfile.cpp
+++ b/src/platform/memoryfile.cpp
@@ -1,6 +1,7 @@
 #include "memoryfile.h"
 
 #include <vector>
+#include <algorithm>
 #include <string.h>
 #include <boost/assert.hpp>
 

--- a/src/platform/pngtexture.cpp
+++ b/src/platform/pngtexture.cpp
@@ -6,6 +6,7 @@
 #include <png.h>
 #include <boost/assert.hpp>
 #include <cstring>
+#include <algorithm>
 
 namespace platform {
 namespace {


### PR DESCRIPTION
The min/max/size_t symbols used in these files were not automatically
included on "some" platforms.
