### PR TITLE
Fix inconsistent my_find_package behaviour (glfw link issue on windows)

### DIFF
--- a/cmake_support/FindDeps.cmake
+++ b/cmake_support/FindDeps.cmake
@@ -18,7 +18,7 @@ find_package( OpenGL )
 # add possible lib names at the end of the arg list
 macro( my_find_package pkg_name header default_lib_name )
 
-    find_package( ${pkg_name} QUIET )
+    find_package( ${pkg_name} QUIET MODULE )
 
     if(NOT ${${pkg_name}_FOUND})
         message(STATUS "Package ${pkg_name} not found! Trying to find paths manually ...")


### PR DESCRIPTION
Original error: the glfw3.lib wasn't linked, because the GLFW_LIBRARIES variable
was empty (instead, only GLFW_LIBRARY was set).

Let's require that the first find_package call only uses cmake modules (and assume
that when/if such a module is available, it sets the plural variable as it should);
and if there is no module, continue with the manual `find_` calls, where we
use consistent variable naming.
