### PR TITLE
Bump boost version, make dependency stricter

### DIFF
--- a/cmake_support/FindDeps.cmake
+++ b/cmake_support/FindDeps.cmake
@@ -6,14 +6,13 @@ if(WIN32)
             add_definitions( -DBOOST_THREAD_USE_LIB )
         endif(MINGW)
 endif(WIN32)
+
 set(Boost_ADDITIONAL_VERSIONS 1.59 1.60)
-find_package( Boost 1.59 COMPONENTS filesystem system thread date_time program_options atomic serialization chrono )
 
-if( NOT Boost_FOUND )
-	message( FATAL_ERROR "Cannot find Boost!" )
-endif()
+find_package( Boost 1.60 EXACT REQUIRED
+        COMPONENTS filesystem system thread date_time program_options atomic serialization chrono )
 
-find_package( OpenGL )
+find_package( OpenGL REQUIRED )
 
 # add possible lib names at the end of the arg list
 macro( my_find_package pkg_name header default_lib_name )


### PR DESCRIPTION
Use EXACT version, since a mismatching boost version might cause issues
between a host and a client.
