### PR TITLE
Optionally build shared glfw libs

### DIFF
--- a/deps/glfw/CMakeLists.txt
+++ b/deps/glfw/CMakeLists.txt
@@ -2,6 +2,14 @@ set(GLFW_URL
         "http://sourceforge.net/projects/glfw/files/glfw/3.0.4/glfw-3.0.4.tar.gz/download"
         CACHE STRING "Location of glfw source package")
 
+if(UNIX)
+    set(GLFW_BUILD_SHARED_DEFAULT ON)
+else(UNIX)
+    set(GLFW_BUILD_SHARED_DEFAULT OFF)
+endif(UNIX)
+
+option(GLFW_BUILD_SHARED "Build shared glfw libs" ${GLFW_BUILD_SHARED_DEFAULT})
+
 ExternalProject_Add(ext_glfw
         PREFIX "${EXTERNALS_WORK_DIR}"
         SOURCE_DIR "${EXTERNALS_WORK_DIR}/src/glfw"
@@ -13,6 +21,7 @@ ExternalProject_Add(ext_glfw
             ${PLATFORM_CMAKE_ARGS}
             ${TOOLCHAIN_CMAKE_ARGS}
             -G ${CMAKE_GENERATOR}
+            -DBUILD_SHARED_LIBS=${GLFW_BUILD_SHARED}
             -DCMAKE_INSTALL_PREFIX=${EXTERNALS_INSTALL_DIR}
             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
 


### PR DESCRIPTION
Default is to build shared on linux and static otherwise, can be
controlled with '-DGLFW_BUILD_SHARED=on|off'
