### PR TITLE
Added Network Thread option.

### DIFF
--- a/run/settings.json
+++ b/run/settings.json
@@ -40,12 +40,12 @@
             "gapless":1,
             "max_cell_size":128,
             "use_size_limit":1,
-            "downsample":0.7
+            "downsample":1
         }
     },
     "network":
     {
-        "threaded":1,
+        "threaded":0,
         "wait_millisec":5
     },
     "soldier_name":

--- a/run/settings.json
+++ b/run/settings.json
@@ -33,7 +33,20 @@
     },
     "graphics":
     {
-        "cast_shadows":1
+        "cast_shadows":0,
+        "sprite_phase_cache":
+        {
+            "enabled":1,
+            "gapless":1,
+            "max_cell_size":128,
+            "use_size_limit":1,
+            "downsample":0.7
+        }
+    },
+    "network":
+    {
+        "threaded":1,
+        "wait_millisec":5
     },
     "soldier_name":
     {

--- a/src/core/map/level_generator/generator_data.cpp
+++ b/src/core/map/level_generator/generator_data.cpp
@@ -62,7 +62,7 @@ void GeneratorData::PlaceRoom( RoomDesc const& roomDesc, glm::vec2 pos, Possible
     gRoomDesc.mRoomDesc.ClearProperties();
     gRoomDesc.mRoomDesc.ClearCellEntrances();
     gRoomDesc.mPossibleRooms = possibleRooms;
-    gRoomDesc.mIsReplaceable = PossibleRooms::IsReplaceable( possibleRooms.GetRoomIds(), gRoomDesc.mRoomDesc.GetRoom()->GetId() );
+    gRoomDesc.mIsReplaceable = possibleRooms.IsReplaceable( gRoomDesc.mRoomDesc.GetRoom()->GetId() );
     mGRoomDescs.push_back( gRoomDesc );
     GenerateGraph();
 }
@@ -98,7 +98,7 @@ bool GeneratorData::CanPlaceRoom( RoomDesc const& roomDesc, glm::vec2 pos, Possi
             }
         }
     }
-    return PossibleRooms::IsReplaceable( possibleRooms.GetRoomIds(), roomDesc.GetRoom()->GetId() )
+    return possibleRooms.IsReplaceable( roomDesc.GetRoom()->GetId() )
             || !HasUnreplaceableNeighbor(*roomDesc.GetRoom(),pos);
 }
 

--- a/src/core/map/level_generator/possible_rooms.cpp
+++ b/src/core/map/level_generator/possible_rooms.cpp
@@ -98,19 +98,19 @@ PossibleRooms::PossibleRoomIds_t PossibleRooms::GetRoomIdsFiltered( RoomDesc con
 }
 
 
-bool PossibleRooms::IsReplaceable( PossibleRooms::PossibleRoomIds_t const& roomIds, int32_t roomId )
+bool PossibleRooms::IsReplaceable(int32_t roomId ) const
 {
-    auto foundSelf = std::find_if( roomIds.begin(), roomIds.end(), [&]( PossibleRoom const& room ) { return room.mRoomId == roomId; } );
-    if (foundSelf != roomIds.end() && foundSelf->mIsBase)
+    auto foundSelf = std::find_if( mUniqueRoomIds.begin(), mUniqueRoomIds.end(), [&]( PossibleRoom const& room ) { return room.mRoomId == roomId; } );
+    if (foundSelf != mUniqueRoomIds.end() && foundSelf->mIsBase)
     {
         return true;
     }
     static auto& mRoomRepo = RoomRepo::Get();
     auto const& roomDesc = mRoomRepo( roomId ).GetRoomDesc();
-    auto found = std::find_if( roomIds.begin(), roomIds.end(), [&]( PossibleRoom const& room ) {
+    auto found = std::find_if( mUniqueRoomIds.begin(), mUniqueRoomIds.end(), [&]( PossibleRoom const& room ) {
             return roomDesc.FitsInto( mRoomRepo( room.mRoomId ).GetRoomDesc(), RoomDesc::Layout ) 
                     && room.mIsBase; } );
-    return found != roomIds.end();
+    return found != mUniqueRoomIds.end();
 }
 
 void PossibleRooms::AddPossibleRoom( int32_t roomId, int32_t possibility, bool isBase )

--- a/src/core/map/level_generator/possible_rooms.h
+++ b/src/core/map/level_generator/possible_rooms.h
@@ -24,7 +24,7 @@ public:
     PossibleRoomIds_t const& GetRoomIds()  const;
     PossibleRoomIds_t GetRoomIdsByProperty( RoomProperty::Type prop, bool shuffled = true ) const;
     PossibleRoomIds_t GetRoomIdsFiltered( RoomDesc const& roomDesc, int32_t flags, bool shuffled = true ) const;
-    static bool IsReplaceable( PossibleRoomIds_t const& roomIds, int32_t roomId );
+    bool IsReplaceable( int32_t roomId ) const;
 private:
     // depending on room weight there can be more than one roomId of the same Id.
     PossibleRoomIds_t mRoomIds;

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -163,31 +163,36 @@ int main( int argc, char* argv[] )
     }
     if ( vm.count( "-c" ) )
     {
-        L1( "run as client" );
         programState.SetMode( ProgramState::Client );
     }
     else if ( vm.count( "-s" ) )
     {
-        L1( "run as server" );
         programState.SetMode( ProgramState::Server );
     }
     else if ( vm.count( "-h" ) )
     {
-        L1( "run as host" );
         programState.SetMode( ProgramState::Client );
         programState.mIsHost = 1;
     }
     else
     {
-        L1( "run local" );
         programState.SetMode( ProgramState::Local );
     }
     if ( vm.count( "-r" ) )
     {
-        L1( "run as a random named soldier. RanBro" );
         programState.SetMode( ProgramState::Client );
         programState.mClientName = "RanBro" + boost::lexical_cast<std::string>( RandomGenerator::global()() % 1000 );
     }
+
+    if (programState.mMode == ProgramState::Server) Logger::Get().SetFileName("log_server.txt");
+    else if (programState.mMode == ProgramState::Local) Logger::Get().SetFileName( "log_local.txt" );
+    else if (programState.mMode == ProgramState::Client) Logger::Get().SetFileName( "log_client_"+programState.mClientName+".txt" );
+
+    if (programState.mMode == ProgramState::Server) L1( "run as server\n" );
+    else if (programState.mMode == ProgramState::Local) L1( "run local\n" );
+    else if (programState.mMode == ProgramState::Client) L1( "run as client: %s\n",programState.mClientName.c_str() );
+
+
     bool calibrateController = vm.count( "calibrate" );
     Filesys::Get().Mount( std::auto_ptr<Package>( new Package( AutoFile( new OsFile( "data.pkg" ) ) ) ) );
     platform::IdStorage::Get().Init();

--- a/src/network/client_system.h
+++ b/src/network/client_system.h
@@ -23,17 +23,17 @@ class ClientSystem: public engine::System
     ModelValue mConnectModel;
     MessageHolder& mMessageHolder;
     ProgramState& mProgramState;
+    
     std::atomic<bool> mRunning;
+    
     bool mThreaded;
     std::thread mThread;
+    int32_t mWaitMillisecs;
+
     void UpdateThread();
-
     void SendMessages();
-
     void ReceiveMessages();
-
     void TransferOutgoingMessagesTo( MessageList::Messages_t& messages );
-
     void PublishIncomingMessages();
 
     AutoReg mOnPhaseChanged;

--- a/src/network/client_system.h
+++ b/src/network/client_system.h
@@ -7,6 +7,8 @@
 #include "platform/i_platform.h"
 #include "messsage_holder.h"
 #include "core/program_state.h"
+#include <atomic>
+#include <thread>
 using platform::ModelValue;
 using core::ProgramState;
 namespace network {
@@ -21,6 +23,21 @@ class ClientSystem: public engine::System
     ModelValue mConnectModel;
     MessageHolder& mMessageHolder;
     ProgramState& mProgramState;
+    std::atomic<bool> mRunning;
+    bool mThreaded;
+    std::thread mThread;
+    void UpdateThread();
+
+    void SendMessages();
+
+    void ReceiveMessages();
+
+    void TransferOutgoingMessagesTo( MessageList::Messages_t& messages );
+
+    void PublishIncomingMessages();
+
+    AutoReg mOnPhaseChanged;
+    void OnPhaseChanged( PhaseChangedEvent const& Evt );
 public:
     DEFINE_SYSTEM_BASE( ClientSystem )
     ClientSystem();

--- a/src/network/message_handler_sub_system_holder.cpp
+++ b/src/network/message_handler_sub_system_holder.cpp
@@ -193,16 +193,19 @@ void MessageHandlerSubSystemHolder::Init()
 
 void MessageHandlerSubSystemHolder::Update( double DeltaTime )
 {
-    for( MessageList::Messages_t::iterator i = mMessageHolder.GetIncomingMessages().mMessages.begin(), e = mMessageHolder.GetIncomingMessages().mMessages.end(); i != e; ++i )
+    // no network threading
+    MessageList::Messages_t messages;
+    mMessageHolder.GetIncomingMessages().TransferPublishedMessagesTo( messages );
+    for( auto& message : messages )
     {
-        Opt<MessageHandlerSubSystem> messageHandlerSS = GetSubSystem( i->GetType() );
+        Opt<MessageHandlerSubSystem> messageHandlerSS = GetSubSystem( message.GetType() );
         if ( messageHandlerSS.IsValid() )
         {
-            messageHandlerSS->Execute( *i );
+            messageHandlerSS->Execute( message );
         }
         else
         {
-            L1( "cannot find subsystem for type! %d", i->GetType() );
+            L1( "cannot find subsystem for type! %d", message.GetType() );
         }
     }
     for( SubSystems_t::iterator it = mSubSystems.begin(), e = mSubSystems.end(); it != e; ++it )

--- a/src/network/messsage_holder.cpp
+++ b/src/network/messsage_holder.cpp
@@ -19,16 +19,6 @@ MessageList& MessageHolder::GetIncomingMessages()
     return mIncomingMessages;
 }
 
-void MessageHolder::ClearOutgoingMessages()
-{
-    mOutgoingMessages.mMessages.clear();
-}
-
-void MessageHolder::ClearIncomingMessages()
-{
-    mIncomingMessages.mMessages.clear();
-}
-
 void MessageList::Add( std::auto_ptr<Message> message )
 {
     mMessages.push_back( message );
@@ -41,14 +31,18 @@ void MessageList::TransferFrom( Messages_t& messages )
 
 void MessageList::Publish()
 {
-    //std::unique_lock<std::mutex> ulock( mMutex );
     mPublishedMessages.transfer( mPublishedMessages.end(), mMessages );
-    //mCV.notify_all();
 }
 
 void MessageList::TransferPublishedMessagesTo( Messages_t& messages )
 {
     messages.transfer( messages.end(), mPublishedMessages );
+}
+
+
+bool MessageList::HasPublishedMessages() const
+{
+    return !mPublishedMessages.empty();
 }
 
 std::mutex& MessageList::GetMutex()
@@ -60,11 +54,5 @@ std::condition_variable& MessageList::GetCV()
 {
     return mCV;
 }
-
-// void MessageList::Wait( std::chrono::milliseconds millisecs )
-// {
-//     std::unique_lock<std::mutex> ulock( mMutex );
-//     mCV.wait_for( ulock, millisecs );
-// }
 
 } // namespace network

--- a/src/network/messsage_holder.cpp
+++ b/src/network/messsage_holder.cpp
@@ -1,4 +1,6 @@
 #include "messsage_holder.h"
+#include <mutex>
+
 namespace network {
 
 
@@ -17,11 +19,6 @@ MessageList& MessageHolder::GetIncomingMessages()
     return mIncomingMessages;
 }
 
-void MessageHolder::AddIncomingMessage( std::auto_ptr<Message> message )
-{
-    mIncomingMessages.mMessages.push_back( message );
-}
-
 void MessageHolder::ClearOutgoingMessages()
 {
     mOutgoingMessages.mMessages.clear();
@@ -31,5 +28,43 @@ void MessageHolder::ClearIncomingMessages()
 {
     mIncomingMessages.mMessages.clear();
 }
+
+void MessageList::Add( std::auto_ptr<Message> message )
+{
+    mMessages.push_back( message );
+}
+
+void MessageList::TransferFrom( Messages_t& messages )
+{
+    mMessages.transfer( mMessages.end(), messages );
+}
+
+void MessageList::Publish()
+{
+    //std::unique_lock<std::mutex> ulock( mMutex );
+    mPublishedMessages.transfer( mPublishedMessages.end(), mMessages );
+    //mCV.notify_all();
+}
+
+void MessageList::TransferPublishedMessagesTo( Messages_t& messages )
+{
+    messages.transfer( messages.end(), mPublishedMessages );
+}
+
+std::mutex& MessageList::GetMutex()
+{
+    return mMutex;
+}
+
+std::condition_variable& MessageList::GetCV()
+{
+    return mCV;
+}
+
+// void MessageList::Wait( std::chrono::milliseconds millisecs )
+// {
+//     std::unique_lock<std::mutex> ulock( mMutex );
+//     mCV.wait_for( ulock, millisecs );
+// }
 
 } // namespace network

--- a/src/network/messsage_holder.h
+++ b/src/network/messsage_holder.h
@@ -32,6 +32,8 @@ public:
     void Publish();
     // needs lock Publish and TransferPublishedMessagesTo can race
     void TransferPublishedMessagesTo( Messages_t& messages);
+    // needs lock. It's just a size ofc.
+    bool HasPublishedMessages() const;
     std::mutex& GetMutex();
     std::condition_variable& GetCV();
 private:
@@ -50,9 +52,6 @@ public:
     MessageList& GetIncomingMessages();
     template<typename MESSAGE>
     void AddOutgoingMessage( std::auto_ptr<MESSAGE> message );
-
-    void ClearOutgoingMessages();
-    void ClearIncomingMessages();
 private:
 
 };

--- a/src/network/messsage_holder.h
+++ b/src/network/messsage_holder.h
@@ -5,20 +5,38 @@
 #include "boost/ptr_container/ptr_list.hpp"
 #include <boost/ptr_container/serialize_ptr_list.hpp>
 #include "boost/static_assert.hpp"
+#include <mutex>              
+#include <condition_variable> 
 
 namespace network {
 
 class MessageList
 {
+public:
+    typedef ::boost::ptr_list<Message> Messages_t;
+    Messages_t mMessages;
+    Messages_t mPublishedMessages;
+
     friend class ::boost::serialization::access;
     template<class Archive>
     void serialize( Archive& ar, const unsigned int version )
     {
-        ar& mMessages;
+        ar& mPublishedMessages;
     }
-public:
-    typedef ::boost::ptr_list<Message> Messages_t;
-    Messages_t mMessages;
+    // no lock needed only the producer thread should access
+    void Add( std::auto_ptr<Message> message );
+    // no lock needed only the producer thread should access
+    void TransferFrom( Messages_t& messages );
+
+    // needs lock Publish and TransferPublishedMessagesTo can race
+    void Publish();
+    // needs lock Publish and TransferPublishedMessagesTo can race
+    void TransferPublishedMessagesTo( Messages_t& messages);
+    std::mutex& GetMutex();
+    std::condition_variable& GetCV();
+private:
+    std::mutex mMutex;
+    std::condition_variable mCV;
 };
 
 class MessageHolder : public platform::Singleton<MessageHolder>
@@ -33,9 +51,9 @@ public:
     template<typename MESSAGE>
     void AddOutgoingMessage( std::auto_ptr<MESSAGE> message );
 
-    void AddIncomingMessage( std::auto_ptr<Message> message );
     void ClearOutgoingMessages();
     void ClearIncomingMessages();
+private:
 
 };
 
@@ -51,7 +69,7 @@ void MessageHolder::AddOutgoingMessage( std::auto_ptr<MESSAGE> message )
             ( boost::is_base_of<Message, MESSAGE>::value ),
             "MESSAGE must be a descendant of Message!"
         );
-        mOutgoingMessages.mMessages.push_back( std::auto_ptr<Message>( message.release() ) );
+        mOutgoingMessages.Add( std::auto_ptr<Message>(message.release()) );
     }
 }
 

--- a/src/network/server_system.cpp
+++ b/src/network/server_system.cpp
@@ -7,6 +7,7 @@
 #include "engine/frame_counter_system.h"
 #include "core/program_state.h"
 #include "engine/connection_event.h"
+#include "platform/settings.h"
 namespace network {
 
 ServerSystem::ServerSystem()
@@ -15,7 +16,10 @@ ServerSystem::ServerSystem()
     , mSentMessagesSize( 0 )
     , mServer( NULL )
     , mAddress()
+    , mRunning( false )
+    , mThreaded( false )
 {
+    mOnPhaseChanged = EventServer<PhaseChangedEvent>::Get().Subscribe( boost::bind( &ServerSystem::OnPhaseChanged, this, _1 ) );
 }
 
 namespace {
@@ -63,53 +67,31 @@ void ServerSystem::Init()
     {
         L1 ( "An error occurred while trying to create an ENet server host.\n" );
     }
+    mThreaded = Settings::Get().GetBool( "network.threaded", true );
+    if (mThreaded)
+    {
+        mRunning = true;
+        mThread = std::thread( boost::bind( &ServerSystem::UpdateThread, this ) );
+    }
 }
 
 void ServerSystem::Update( double DeltaTime )
 {
     PerfTimer.Log( "server update started" );
-    ENetEvent event;
-    while( enet_host_service ( mServer, & event, 0 ) > 0 )
+
+    if (mThreaded)
     {
-        //PerfTimer.Log("server enter");
-        switch ( event.type )
-        {
-        case ENET_EVENT_TYPE_CONNECT:
-            ClientConnect( event );
-            break;
-        case ENET_EVENT_TYPE_RECEIVE:
-            Receive( event );
-            break;
-
-        case ENET_EVENT_TYPE_DISCONNECT:
-            ClientDisconnect( event );
-            break;
-        }
+        std::lock_guard<std::mutex> lck( mMessageHolder.GetOutgoingMessages().GetMutex() );
+        mMessageHolder.GetOutgoingMessages().Publish();
+        mMessageHolder.GetOutgoingMessages().GetCV().notify_all();
     }
-    PerfTimer.Log( "server receive ended" );
-
-
-    // no network threading
-    mMessageHolder.GetIncomingMessages().Publish();
-    mMessageHolder.GetOutgoingMessages().Publish();
-
-    MessageList::Messages_t messages;
-    mMessageHolder.GetOutgoingMessages().TransferPublishedMessagesTo( messages );
-    if ( !messages.empty() )
+    else
     {
-        std::ostringstream oss;
-        eos::portable_oarchive oa( oss );
-        oa & messages;
-        std::string astr( oss.str() );
-        // L1("server sends - %s:\n",astr.c_str());
-        ENetPacket* packet = enet_packet_create ( astr.c_str(),
-                             astr.size(),
-                             ENET_PACKET_FLAG_RELIABLE );
-        mSentMessagesSize += packet->dataLength * mClients.size();
-
-        enet_host_broadcast( mServer, 0, packet );
-        enet_host_flush( mServer );
+        ReceiveMessages();
+        mMessageHolder.GetOutgoingMessages().Publish();
+        SendMessages();
     }
+
     PerfTimer.Log( "server update ended" );
 
 }
@@ -144,10 +126,11 @@ void ServerSystem::SetSenderId( MessageList::Messages_t& messages, ENetEvent& ev
 
 void ServerSystem::ClientConnect( ENetEvent& event )
 {
-    L1 ( "A new client connected from %x:%u.\n",
-         event.peer -> address.host,
-         event.peer -> address.port );
+//     L1 ( "A new client connected from %x:%u.\n",
+//          event.peer -> address.host,
+//          event.peer -> address.port );
     /* Store any relevant client information here. */
+    std::lock_guard<std::mutex> lck( mClientsMutex );
     int32_t clientId = mClientId++;
     event.peer -> data = static_cast<void*>( new int32_t( clientId ) );
     mClients[clientId] = event.peer;
@@ -161,13 +144,14 @@ void ServerSystem::OnFrameCounterEvent( engine::FrameCounterEvent const& Evt )
 
 void ServerSystem::ClientDisconnect( ENetEvent& event )
 {
+    std::lock_guard<std::mutex> lck( mClientsMutex );
     int32_t clientId = *static_cast<int32_t*>( event.peer -> data );
     Opt<core::ClientData> clientData( core::ProgramState::Get().FindClientDataByClientId( clientId ) );
-    L1 ( "client disconnected: %x:%u. client id: %d, name: %s\n",
-         event.peer -> address.host,
-         event.peer -> address.port,
-         clientId,
-         clientData.IsValid() ? clientData->mClientName.c_str() : "_no_name_" );
+//     L1 ( "client disconnected: %x:%u. client id: %d, name: %s\n",
+//          event.peer -> address.host,
+//          event.peer -> address.port,
+//          clientId,
+//          clientData.IsValid() ? clientData->mClientName.c_str() : "_no_name_" );
     /* Reset the peer's client information. */
     delete static_cast<int32_t*>( event.peer->data );
     event.peer -> data = NULL;
@@ -182,6 +166,7 @@ void ServerSystem::ClientDisconnect( ENetEvent& event )
 
 void ServerSystem::OnClientIdChanged( ClientIdChangedEvent const& Evt )
 {
+    std::lock_guard<std::mutex> lck( mClientsMutex );
     auto currPeer = mClients.find( Evt.mCurrClientId );
     if ( currPeer == mClients.end() )
     {
@@ -195,6 +180,97 @@ void ServerSystem::OnClientIdChanged( ClientIdChangedEvent const& Evt )
     currPeer->second -> data = static_cast<void*>( new int32_t( Evt.mNewClientId ) );
     mClients[Evt.mNewClientId] = currPeer->second;
     mClients.erase( Evt.mCurrClientId );
+}
+
+void ServerSystem::UpdateThread()
+{
+    while (mRunning)
+    {
+        ReceiveMessages();
+        SendMessages();
+    }
+}
+
+void ServerSystem::SendMessages()
+{
+    MessageList::Messages_t messages;
+    TransferOutgoingMessagesTo( messages );
+    if (!messages.empty())
+    {
+        std::ostringstream oss;
+        eos::portable_oarchive oa( oss );
+        oa & messages;
+        std::string astr( oss.str() );
+        // L1("server sends - %s:\n",astr.c_str());
+        ENetPacket* packet = enet_packet_create( astr.c_str(),
+            astr.size(),
+            ENET_PACKET_FLAG_RELIABLE );
+
+        enet_host_broadcast( mServer, 0, packet );
+        enet_host_flush( mServer );
+    }
+}
+
+void ServerSystem::ReceiveMessages()
+{
+    ENetEvent event;
+    while (enet_host_service( mServer, &event, 0 ) > 0)
+    {
+        switch (event.type)
+        {
+        case ENET_EVENT_TYPE_CONNECT:
+            ClientConnect( event );
+            break;
+        case ENET_EVENT_TYPE_RECEIVE:
+            Receive( event );
+            break;
+
+        case ENET_EVENT_TYPE_DISCONNECT:
+            ClientDisconnect( event );
+            break;
+        }
+    }
+    PublishIncomingMessages();
+}
+
+void ServerSystem::TransferOutgoingMessagesTo( MessageList::Messages_t& messages )
+{
+    if (mThreaded)
+    {
+        static const int32_t mWaitMillisecs = Settings::Get().GetInt( "network.wait_millisec", 10 );
+        std::unique_lock<std::mutex> ulck( mMessageHolder.GetOutgoingMessages().GetMutex() );
+        if (!mMessageHolder.GetOutgoingMessages().HasPublishedMessages())
+        {
+            mMessageHolder.GetOutgoingMessages().GetCV().wait_for( ulck, std::chrono::milliseconds( mWaitMillisecs ) );
+        }
+        mMessageHolder.GetOutgoingMessages().TransferPublishedMessagesTo( messages );
+    }
+    else
+    {
+        mMessageHolder.GetOutgoingMessages().TransferPublishedMessagesTo( messages );
+    }
+}
+
+void ServerSystem::PublishIncomingMessages()
+{
+    if (mThreaded)
+    {
+        std::lock_guard<std::mutex> lck( mMessageHolder.GetIncomingMessages().GetMutex() );
+        mMessageHolder.GetIncomingMessages().Publish();
+    }
+    else
+    {
+        mMessageHolder.GetIncomingMessages().Publish();
+    }
+}
+
+void ServerSystem::OnPhaseChanged( PhaseChangedEvent const& Evt )
+{
+    if (mThreaded && Evt.CurrentPhase == ProgramPhase::CloseSignal)
+    {
+        mRunning = false;
+        mThread.join();
+    }
 }
 
 } // namespace engine

--- a/src/network/server_system.cpp
+++ b/src/network/server_system.cpp
@@ -67,10 +67,10 @@ void ServerSystem::Init()
     {
         L1 ( "An error occurred while trying to create an ENet server host.\n" );
     }
+    mRunning = true;
     mThreaded = Settings::Get().GetBool( "network.threaded", true );
     if (mThreaded)
     {
-        mRunning = true;
         mThread = std::thread( boost::bind( &ServerSystem::UpdateThread, this ) );
     }
 }

--- a/src/network/server_system.h
+++ b/src/network/server_system.h
@@ -9,6 +9,8 @@
 #include "engine/frame_counter_system.h"
 #include "platform/register.h"
 #include "client_id_changed.h"
+#include <atomic>
+#include <thread>
 
 namespace network {
 
@@ -17,6 +19,7 @@ class ServerSystem: public engine::System
     ENetAddress mAddress;
     ENetHost* mServer;
     typedef std::map<int32_t, ENetPeer*> Clients_t;
+    std::mutex mClientsMutex;
     Clients_t mClients;
     int32_t mClientId;
     MessageHolder& mMessageHolder;
@@ -25,6 +28,22 @@ class ServerSystem: public engine::System
     AutoReg mOnClientIdChanged;
     void OnClientIdChanged( ClientIdChangedEvent const& Evt );
     int32_t mSentMessagesSize;
+
+    std::atomic<bool> mRunning;
+    bool mThreaded;
+    std::thread mThread;
+    void UpdateThread();
+
+    void SendMessages();
+
+    void ReceiveMessages();
+
+    void TransferOutgoingMessagesTo( MessageList::Messages_t& messages );
+
+    void PublishIncomingMessages();
+
+    AutoReg mOnPhaseChanged;
+    void OnPhaseChanged( PhaseChangedEvent const& Evt );
 public:
     DEFINE_SYSTEM_BASE( ServerSystem )
     ServerSystem();

--- a/src/network/server_system.h
+++ b/src/network/server_system.h
@@ -37,7 +37,7 @@ public:
 
     void Receive( ENetEvent& event );
 
-    void SetSenderId( MessageList& msglist, ENetEvent& event );
+    void SetSenderId( MessageList::Messages_t& messages, ENetEvent& event );
 };
 
 } // namespace network

--- a/src/network/server_system.h
+++ b/src/network/server_system.h
@@ -30,16 +30,14 @@ class ServerSystem: public engine::System
     int32_t mSentMessagesSize;
 
     std::atomic<bool> mRunning;
+
     bool mThreaded;
     std::thread mThread;
+
     void UpdateThread();
-
     void SendMessages();
-
     void ReceiveMessages();
-
     void TransferOutgoingMessagesTo( MessageList::Messages_t& messages );
-
     void PublishIncomingMessages();
 
     AutoReg mOnPhaseChanged;

--- a/src/platform/log.cpp
+++ b/src/platform/log.cpp
@@ -12,7 +12,7 @@ namespace platform {
 
 void Logger::Log( int Level, char const* format, ... )
 {
-    if( mDisabledLevels & ( 1 << Level ) )
+    if( mDisabledLevels & ( 1 << Level )||mLogFile.mFile==nullptr )
     {
         return;
     }
@@ -31,7 +31,7 @@ void Logger::Log( int Level, char const* format, ... )
 
 Logger::Logger()
     : mDisabledLevels( 0 )
-    , mLogFile( "log.txt", "w" )
+    , mLogFile()
 {
     std::auto_ptr<File> f( new OsFile( "debug.json" ) );
     if( !f.get() || !f->IsValid() )
@@ -67,14 +67,32 @@ Logger::Logger()
 }
 
 
+void Logger::SetFileName( std::string filename )
+{
+    if (mLogFile.mFile)
+    {
+        fclose( mLogFile.mFile );
+    }
+    mLogFile.mFile = fopen( filename.c_str(), "w" );
+}
+
 AutoNormalFile::AutoNormalFile( const char* name, const char* mode )
 {
     mFile = fopen ( name, mode );
 }
 
+
+AutoNormalFile::AutoNormalFile()
+{
+
+}
+
 AutoNormalFile::~AutoNormalFile()
 {
-    fclose( mFile );
+    if (mFile)
+    {
+        fclose( mFile );
+    }
 }
 
 } // namespace platform

--- a/src/platform/log.h
+++ b/src/platform/log.h
@@ -8,8 +8,9 @@ namespace platform {
 
 struct AutoNormalFile
 {
-    FILE* mFile;
+    FILE* mFile = nullptr;
     AutoNormalFile( const char* name, const char* mode );
+    AutoNormalFile();
     ~AutoNormalFile();
 };
 
@@ -21,6 +22,7 @@ class Logger : public Singleton<Logger>
     size_t mDisabledLevels;
 public:
     void Log( int Level, char const* format, ... );
+    void SetFileName( std::string filename );
 };
 
 } // namespace platform

--- a/src/platform/settings.cpp
+++ b/src/platform/settings.cpp
@@ -113,3 +113,22 @@ Json::Value Settings::Resolve(std::string const& key) const
     return r;
 }
 
+bool Settings::GetBool( std::string const& key, bool Default /*= true */ ) const
+{
+    int32_t i = Default?1:0;
+    if (Json::GetInt( Resolve( key ), i ))
+    {
+        return i != 0;
+    }
+    std::string s = Default?"true":"false";
+    if (Json::GetStr( Resolve( key ), s ))
+    {
+        return boost::iequals( s, "true" )
+            || boost::iequals( s, "t" )
+            || boost::iequals( s, "1" )
+            || boost::iequals( s, "y" )
+            || boost::iequals( s, "yes" );
+    }
+    return Default;
+}
+

--- a/src/platform/settings.cpp
+++ b/src/platform/settings.cpp
@@ -123,11 +123,11 @@ bool Settings::GetBool( std::string const& key, bool Default /*= true */ ) const
     std::string s = Default?"true":"false";
     if (Json::GetStr( Resolve( key ), s ))
     {
-        return boost::iequals( s, "true" )
-            || boost::iequals( s, "t" )
-            || boost::iequals( s, "1" )
-            || boost::iequals( s, "y" )
-            || boost::iequals( s, "yes" );
+        return !(boost::iequals( s, "false" )
+            || boost::iequals( s, "f" )
+            || boost::iequals( s, "0" )
+            || boost::iequals( s, "n" )
+            || boost::iequals( s, "no" ));
     }
     return Default;
 }

--- a/src/platform/settings.h
+++ b/src/platform/settings.h
@@ -13,6 +13,7 @@ public:
     float GetFloat(std::string const& key, float Default = 0.0f) const;
     int32_t GetColor(std::string const& key, int32_t Default = 0.0f) const;
     glm::vec4 GetColor(std::string const& key, glm::vec4 Default = glm::vec4(0.0)) const;
+    bool GetBool( std::string const& key, bool Default = true ) const;
     Json::Value Resolve(std::string const& key) const;
 private:
     friend class platform::Singleton<Settings>;

--- a/src/platform/singleton.h
+++ b/src/platform/singleton.h
@@ -14,21 +14,12 @@ class Singleton
 public:
     static T& Get()
     {
-        BOOST_ASSERT( !is_destructed );
         static T instance;
         return instance;
     }
     Singleton() {}
-    virtual ~Singleton()
-    {
-        is_destructed = true;
-    }
-private:
-    static volatile bool is_destructed;
+    virtual ~Singleton() {}
 };
-
-template<typename T>
-volatile bool Singleton<T>::is_destructed = false;
 
 } // namespace platform
 

--- a/src/platform/singleton.h
+++ b/src/platform/singleton.h
@@ -15,15 +15,6 @@ public:
     static T& Get()
     {
         BOOST_ASSERT( !is_destructed );
-        ( void )is_destructed; // prevent removing is_destructed in Release configuration
-        try
-        {
-            boost::mutex::scoped_lock lock( GetMutex() );
-        }
-        catch( boost::lock_error const& )
-        {
-            abort();
-        }
         static T instance;
         return instance;
     }
@@ -33,18 +24,11 @@ public:
         is_destructed = true;
     }
 private:
-    static bool is_destructed;
-
-    static boost::mutex& GetMutex()
-    {
-        static boost::mutex mutex;
-        return mutex;
-    }
+    static volatile bool is_destructed;
 };
 
-// force creating mutex before main() is called
 template<typename T>
-bool Singleton<T>::is_destructed = ( Singleton<T>::GetMutex(), false );
+volatile bool Singleton<T>::is_destructed = false;
 
 } // namespace platform
 


### PR DESCRIPTION
Main goal is to maintain the network heartbeat under big load on server. Without major performance hit. Using a thread for network can be turned on or off by: "network.threaded":1/0.

Added a GetBool to settings, and updated singleton to c++11. No mutex or locking is needed for init static.

Added different log file name to different start modes.